### PR TITLE
Remove phantomjs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ or by using [http://postgresapp.com](http://postgresapp.com).
 Have a look at these [further instructions for installing Postgres via Homebrew](http://www.mikeball.us/blog/setting-up-postgres-with-homebrew/):
 
 ```bash
-brew install postgres phantomjs
+brew install postgres
 ```
 
 On Debian-based Linux distributions you can use apt-get to install Postgres:


### PR DESCRIPTION
It doesn’t seem to be used anywhere, so I assume this was accidentally
copied verbatim from https://github.com/24pullrequests/24pullrequests/blob/master/Readme.md.