### PR TITLE
Add event index and show actions and link to events where mentioned

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,6 +11,14 @@ class EventsController < ApplicationController
     redirect_to new_event_path
   end
 
+  def index
+    @events = Event.all.order('name ASC, year ASC')
+  end
+
+  def show
+    @event = Event.find(params[:id])
+  end
+
   private
 
   def event_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,6 +4,8 @@ class Event < ApplicationRecord
   validates_numericality_of :year, only_integer: true
   validates_uniqueness_of :name, scope: :year
 
+  has_many :submissions
+
   def name_and_year
     "#{name} #{year}"
   end

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,5 @@
+<h3>Conferences</h3>
+
+<% @events.each do |event| %>
+  <p><%= link_to event.name_and_year, event %></p>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,10 @@
+<h3><%= @event.name_and_year %></h3>
+
+<h5>Proposals</h5>
+<% @event.submissions.each do |submission| %>
+  <p>
+    <%= link_to submission.proposal.title, submission.proposal %> -
+    <%= link_to submission.proposal.speaker.name, submission.proposal.speaker %> -
+    <%= submission.result.capitalize %>
+  </p>
+<% end %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -9,9 +9,11 @@
   <div class="one-half column">
     <h4>Submissions </h4>
     <% @proposal.submissions.each do |submission| %>
-      <p><%= "#{submission.event.name} #{submission.event.year} — #{submission.result.capitalize}" %></p>
+      <p>
+        <%= link_to submission.event.name_and_year, submission.event %> -
+        <%= submission.result.capitalize %>
+      </p>
   <% end %>
     <%= link_to 'Add submission', new_submission_path(proposal: @proposal.id) %>
   </div>
 </div>
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
   resources :speakers
   resources :proposals, only: [:new, :create, :show]
   resources :submissions, only: [:new, :create]
-  resources :events, only: [:new, :create]
+  resources :events
 end

--- a/features/step_definitions/proposal_page.rb
+++ b/features/step_definitions/proposal_page.rb
@@ -35,7 +35,7 @@ Given(/^Saron Yitbarek's 'Reading Code Good' was accepted at RailsConf 2014$/) d
 end
 
 Then(/^I should see a record of the RailsConf 2014 acceptance$/) do
-  expect(page).to have_content('RailsConf 2014 — Accepted')
+  expect(page).to have_content('RailsConf 2014 - Accepted')
 end
 
 When(/^I add that the proposal was rejected from Boo Ruby in 2017$/) do
@@ -50,5 +50,5 @@ Given(/^there is an (\d+) event called "([^"]*)" in the system$/) do |year, even
 end
 
 Then(/^I should see a record of the Boo Ruby 2017 rejection$/) do
-  expect(page).to have_content('Boo Ruby 2017 — Rejected')
+  expect(page).to have_content('Boo Ruby 2017 - Rejected')
 end


### PR DESCRIPTION
I thought it would be neat to see an overview of all the proposals to a particular event, as well as a list of events, so here they are!

![screen shot 2017-03-23 at 9 01 36 pm](https://cloud.githubusercontent.com/assets/1060/24270170/ee703670-100b-11e7-84ad-5873a486628b.png)

![screen shot 2017-03-23 at 9 00 21 pm](https://cloud.githubusercontent.com/assets/1060/24270145/d7d1ca0a-100b-11e7-8c81-1fe7144a5ee2.png)
