### PR TITLE
Add viewport meta tag for friendlier mobile experience, fixes #16

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
     <title>Speakerline</title>
     <%= csrf_meta_tags %>
     <meta name="description" content="Showcasing speakers' proposals and timelines in an effort to demystify the CFP process and help new speakers get started.">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>


### PR DESCRIPTION
More details on the viewport meta tag here: https://css-tricks.com/snippets/html/responsive-meta-tag/

![screen shot 2017-03-27 at 9 08 51 am](https://cloud.githubusercontent.com/assets/1060/24346656/34228060-12cd-11e7-8306-48ec6072ace2.png)
