### PR TITLE
Add badge to track dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Speakerline
 
 [![Build Status](https://travis-ci.org/nodunayo/speakerline.svg?branch=master)](https://travis-ci.org/nodunayo/speakerline)
+[![Dependency Status](https://gemnasium.com/badges/github.com/nodunayo/speakerline.svg)](https://gemnasium.com/github.com/nodunayo/speakerline)
 
 > Showcasing speakers' proposals and timelines in a effort to demystify the CFP process and help new speakers get started
 


### PR DESCRIPTION
This way we can see if there's dependencies we need to update and stay on top of latest versions and vulnerabilities.
