### PR TITLE
Issue 34 - Failed creation of a submission returns to form

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -11,7 +11,7 @@ class SubmissionsController < ApplicationController
       redirect_to proposal_path(@submission.proposal)
     else
       flash[:alert] = 'Failed to save submission'
-      redirect_to speakers_path
+      redirect_to new_submission_path(proposal: @submission.proposal.id)
     end
   end
 

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -2,9 +2,11 @@ require 'rails_helper'
 
 RSpec.describe SubmissionsController do
   describe 'POST #create' do
+
+    let(:proposal) { create(:proposal) }
+
     context 'with valid attributes' do
 
-      let(:proposal) { create(:proposal) }
       let(:expected_submission) { Submission.new(proposal: proposal, result: 0) }
 
       before do
@@ -20,18 +22,21 @@ RSpec.describe SubmissionsController do
       it { should redirect_to(proposal_path(assigns(:submission).proposal)) }
     end
 
-    context 'with invalid attributes' do
-      let(:invalid_submission) { double }
+    context 'with a valid submission attribute and invalid event and proposal id attributes' do
+      let(:invalid_submission) { Submission.new(proposal: proposal, result: '') }
 
       before do
         allow(Submission).to receive(:new).and_return(invalid_submission)
         allow(invalid_submission).to receive(:save).and_return(false)
 
-        post :create, params: { submission: { result: '' } }
+        post :create, params: { submission: { event_id: '', proposal_id: proposal.id, result: '' } }
       end
 
       it { is_expected.to set_flash[:alert].to('Failed to save submission') }
-      it { should redirect_to(speakers_path) }
+      it { should redirect_to(new_submission_path(proposal: invalid_submission.proposal.id)) }
+      it 'should retain its proposal id' do
+        expect(response.location).to include("?proposal=#{invalid_submission.proposal.id}")
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes [issue 34](https://github.com/nodunayo/speakerline/issues/34), where
invalid create actions on the SubmissionsController would redirect
to the speakers index, instead of back to the form.

#### What does this PR do?

Currently, when a user tries to create an invalid submission (submission of a proposal, not a form submission), the app currently redirects them to the speakers index instead of back to the form.

This PR changes this flow so the user is redirect back to the submission creation form.

It also changes the spec for the `SubmissionsController` so that it tests not submissions with all invalid attributes, but submissions with all attributes invalid except for the proposal ID.

This PR does *not* test the case when all submitted attributes are invalid, because this actually opens questions about the `SubmissionsController` routing behavior: it displays Rails errors when the user accesses `/submissions/new` without a proposal ID URL attribute. ([Issue 48](https://github.com/nodunayo/speakerline/issues/48) opened for this).

##### Why was this work done? Is there a related Issue?

Fixes [issue 34](https://github.com/nodunayo/speakerline/issues/34); also part of 24 Pull Requests.

#### Where should a reviewer start?

The only changes are in the `SubmissionsController` and its spec file. 

Worth noting, in the spec, the `let(:proposal)...` declaration was moved so it can be accessed in both contexts, and the invalid attrs context no longer uses an anonymous double because it needs a valid proposal attribute.

The additional expectation that the action `should retain its proposal id` (line 37) is technically redundant because the redirect expectation on line 36 already catches this, but feels useful in case something else happens to the URL structure.

#### Are there any manual testing steps?

1. (Add a speaker)
2. (Add a proposal for the speaker)
3. Create a submission for the proposal without selecting a "Accepted/Rejected" result
4. Confirm you are redirected back to the submission form

---

#### Screenshots

#### Deployment instructions

#### Database changes

#### New ENV variables
