### PR TITLE
Add a 'waitlisted' option to submissions

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -6,5 +6,5 @@ class Submission < ApplicationRecord
   validates_presence_of :proposal
   validates_presence_of :result
 
-  enum result: [ :accepted, :rejected ]
+  enum result: [ :accepted, :rejected, :waitlisted ]
 end

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -7,6 +7,8 @@
   <%= f.radio_button(:result, :accepted) %>
   <%= f.label(:result_rejected, "Rejected") %>
   <%= f.radio_button(:result, :rejected) %>
+  <%= f.label(:result_waitlisted, "Waitlisted") %>
+  <%= f.radio_button(:result, :waitlisted) %>
   <%= recaptcha_tags %>
   <%= f.submit "Add submission" %>
 <% end %>

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -4,5 +4,5 @@ RSpec.describe Submission do
   it { should validate_presence_of(:event) }
   it { should validate_presence_of(:proposal) }
   it { should validate_presence_of(:result) }
-  it { should define_enum_for(:result).with([:accepted, :rejected]) }
+  it { should define_enum_for(:result).with([:accepted, :rejected, :waitlisted]) }
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -4,4 +4,5 @@ RSpec.describe Submission do
   it { should validate_presence_of(:event) }
   it { should validate_presence_of(:proposal) }
   it { should validate_presence_of(:result) }
+  it { should define_enum_for(:result).with([:accepted, :rejected]) }
 end


### PR DESCRIPTION
@acuppy sent me a lot of proposals to add to the site and one of them was waitlisted at a conference. Working on conference committees I know that a few talks are often always put on a waitlist. We should display this information on the website as 'waitlisted' is very different from 'rejected' or 'accepted'.