### PR TITLE
keep submitters progress on failed save of proposal

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -16,7 +16,8 @@ class ProposalsController < ApplicationController
       redirect_to proposal_path(@proposal)
     else
       flash[:alert] = 'Failed to save proposal'
-      redirect_to new_proposal_path
+      @speakers = speakers
+      render 'new'
     end
   end
 

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe ProposalsController do
     end
 
     context 'with invalid attributes' do
-      let(:invalid_proposal) { Proposal.new(title: nil) }
+      render_views
+      let(:invalid_proposal) { Proposal.new(title: nil, body: 'My progress should be shown') }
 
       before do
         allow(Proposal).to receive(:new).and_return(invalid_proposal)
@@ -29,7 +30,7 @@ RSpec.describe ProposalsController do
       end
 
       it { is_expected.to set_flash[:alert].to('Failed to save proposal') }
-      it { should redirect_to(new_proposal_path) }
+      it { expect(response.body).to have_content 'My progress should be shown' }
     end
   end
 


### PR DESCRIPTION
#### What does this PR do?
Upon failing to save a proposal submission, the re-rendered proposals#new page shows the submitters progress so they can fix it/continue where they left off.
##### Why was this work done? Is there a related Issue?
#35 Upon failing to save a proposal, keep the submitter's progress!
#### Where should a reviewer start?
proposals_controller


