### PR TITLE
Closes #33 Speaker index page is not one long list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
     turbolinks-source (5.0.3)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    uglifier (4.0.0)
+    uglifier (4.0.1)
       execjs (>= 0.3.0, < 3)
     web-console (3.5.1)
       actionview (>= 5.0)
@@ -315,5 +315,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.16.0.pre.2
-
+   1.16.0

--- a/app/views/speakers/index.html.erb
+++ b/app/views/speakers/index.html.erb
@@ -1,3 +1,9 @@
-<% @speakers.each do |speaker| %>
-  <p><%= link_to speaker.name, speaker_path(speaker.id) %></p>
-<% end %>
+<table>
+  <% @speakers.in_groups_of(3, false) do |row_speakers| %>
+  <tr>
+    <% for speaker in row_speakers %>
+    <td><%= link_to speaker.name, speaker_path(speaker.id) %></td>
+    <% end %>
+  </tr>
+  <% end %>
+</table>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,14 +15,14 @@ ActiveRecord::Schema.define(version: 20170319134913) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "events", id: :serial, force: :cascade do |t|
+  create_table "events", force: :cascade do |t|
     t.string "name", null: false
-    t.integer "year", null: false
+    t.string "year", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "proposals", id: :serial, force: :cascade do |t|
+  create_table "proposals", force: :cascade do |t|
     t.string "title"
     t.text "body"
     t.datetime "created_at", null: false
@@ -31,13 +31,13 @@ ActiveRecord::Schema.define(version: 20170319134913) do
     t.index ["speaker_id"], name: "index_proposals_on_speaker_id"
   end
 
-  create_table "speakers", id: :serial, force: :cascade do |t|
+  create_table "speakers", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "submissions", id: :serial, force: :cascade do |t|
+  create_table "submissions", force: :cascade do |t|
     t.integer "result"
     t.integer "proposal_id"
     t.integer "event_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,15 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+Speaker.destroy_all
+Speaker.create!(name: "Andrew Anderson")
+Speaker.create!(name: "Bill Billson")
+Speaker.create!(name: "Charlie Charleson")
+Speaker.create!(name: "Donald Donaldson")
+Speaker.create!(name: "Edward Edwardson")
+Speaker.create!(name: "Freddie Frederickson")
+Speaker.create!(name: "George Georgeson")
+Speaker.create!(name: "Harry Harrison")
+Speaker.create!(name: "Ian Ianson")
+Speaker.create!(name: "John Johnson")


### PR DESCRIPTION
#### What does this PR do?
* Splits speaker index list into three columns. Three selected instead of four to keep it reasonably tidy on small screens. 

##### Why was this work done? Is there a related Issue?
* #33 Speaker index page is not one long list

#### Where should a reviewer start?
* Final commit only is relevant 

#### Are there any manual testing steps?
* Change is visual, all tests still passing

---

#### Screenshots
<img width="610" alt="screen shot 2017-12-07 at 15 08 12" src="https://user-images.githubusercontent.com/19407259/33722622-6316ba18-db62-11e7-8250-2a71c0e8934e.png">

#### Deployment instructions
* None

#### Database changes
* None

#### New ENV variables
* None

Hope this is what you were looking for! 

The only file that should be merged is the one in the final commit cfd93033600a93182f79a0d0bbbcef82a5faed89. 
Can you just cherry pick this or should I submit it a different way?

Thanks for the encouragement and clear opportunity to contribute.
All feedback welcomed!