### PR TITLE
32 - Speakers with no proposals should not show up on the homepage

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -1,6 +1,6 @@
 class SpeakersController < ApplicationController
   def index
-    @speakers = Speaker.all.order('name ASC')
+    @speakers = Speaker.joins(:proposals).distinct.order('name ASC')
   end
 
   def show

--- a/features/speaker_directory.feature
+++ b/features/speaker_directory.feature
@@ -1,9 +1,16 @@
 Feature: Speaker Directory
 
-  Scenario: View speakers in the directory
+  Scenario: View speakers with proposals in the directory
     Given the speaker 'Sandi Metz' is in the directory
+    And Sandi already has a proposal
     When I go to the speaker directory page
     Then I should see 'Sandi Metz'
+
+  Scenario: Speakers without proposals do not appear in the directory
+    Given the speaker 'Lazy Ted' is in the directory
+    And Ted does not have any proposals
+    When I go to the speaker directory page
+    Then I should not see 'Lazy Ted'
 
   Scenario: Go to a speaker's page
     Given 'Sandi Metz' has a proposal entitled 'All The Little Things'
@@ -14,6 +21,7 @@ Feature: Speaker Directory
   Scenario: Add a speaker to the directory
     Given the speaker 'Katrina Owen' is not in the directory
     When I add 'Katrina Owen' to the directory
+    And I create a proposal for Katrina
     And I go to the speaker directory page
     Then I should see 'Katrina Owen'
 

--- a/features/step_definitions/speaker_directory.rb
+++ b/features/step_definitions/speaker_directory.rb
@@ -2,6 +2,19 @@ Given(/^the speaker 'Sandi Metz' is in the directory$/) do
   create(:speaker, name: 'Sandi Metz')
 end
 
+Given(/^Sandi already has a proposal$/) do
+  create(:proposal, speaker: Speaker.find_by(name: 'Sandi Metz'))
+end
+
+Given(/^the speaker 'Lazy Ted' is in the directory$/) do
+  create(:speaker, name: 'Lazy Ted')
+end
+
+Given(/^Ted does not have any proposals$/) do
+  id = Speaker.find_by(name: 'Lazy Ted').id
+  expect(Proposal.find_by(speaker_id: id)).to be_nil
+end
+
 Given(/^the speaker 'Saron Yitbarek' is in the directory$/) do
   create(:speaker, name: 'Saron Yitbarek')
 end
@@ -12,6 +25,10 @@ end
 
 Then(/^I should see 'Sandi Metz'$/) do
   expect(page).to have_content('Sandi Metz')
+end
+
+Then(/^I should not see 'Lazy Ted'$/) do
+  expect(page).not_to have_content('Lazy Ted')
 end
 
 Given(/^'Sandi Metz' has a proposal entitled 'All The Little Things'$/) do
@@ -37,6 +54,11 @@ When(/^I add 'Katrina Owen' to the directory$/) do
   visit new_speaker_path
   page.fill_in 'speaker_name', with: 'Katrina Owen'
   page.click_on 'Add'
+end
+
+When(/^I create a proposal for Katrina$/) do
+  speaker = Speaker.find_by(name: 'Katrina Owen')
+  create(:proposal, speaker: speaker)
 end
 
 Then(/^I should see 'Katrina Owen'$/) do

--- a/spec/controllers/speakers_controller_spec.rb
+++ b/spec/controllers/speakers_controller_spec.rb
@@ -2,17 +2,28 @@ require 'rails_helper'
 
 RSpec.describe SpeakersController do
   describe 'GET #index' do
-      context 'when viewing the Speakers#index page' do
-        before do
-          create(:speaker, name: "Zebra")
-          create(:speaker, name: "Angel")
-          get :index
-        end
+    context 'when viewing the Speakers#index page' do
+      before do
+        create(:speaker, name: "Zebra")
+        create(:speaker, name: "LazyTed")
+        create(:speaker, name: "Angel")
 
-        it 'lists the speakers in alphabetical order' do
-          expect(assigns(:speakers).first.name).to eq("Angel")
+        create(:proposal, speaker: Speaker.find_by(name: "Angel"))
+        create(:proposal, speaker: Speaker.find_by(name: "Zebra"))
+
+        get :index
+      end
+
+      it 'lists the speakers in alphabetical order' do
+        expect(assigns(:speakers).first.name).to eq("Angel")
+      end
+
+      it 'does not show speakers without proposals' do
+        assigns(:speakers).each do |s|
+          expect(s.name).not_to eq("LazyTed")
         end
       end
+    end
   end
 
   describe 'POST #create' do


### PR DESCRIPTION
#### What does this PR do?

This PR updates the `Speakers#index` action to list only speakers that have proposals; it reintroduces code from [PR 53 (reverted)](https://github.com/nodunayo/speakerline/pull/53), and fixes a bug that caused a Speaker to be show once for each proposal they had.

It updates the `SpeakersController`, its spec, and the speaker directory feature tests.

##### Why was this work done? Is there a related Issue?

Address issue https://github.com/nodunayo/speakerline/issues/32; part of [24 Pull Requests](https://24pullrequests.com).

This second PR fixes a bug that caused speakers to be shown once per proposal associated with them.

#### Where should a reviewer start?

The controller change is small (1 line); the feature changes need more attention:

Features changes:

- the scenario for `Viewing speakers in the directory` has changed to `Viewing speakers with proposals in the directory`, and has an additional step that creates a proposal for the speaker 'Sandi Metz`
- similarly, the scenario `Add a speaker to the directory` includes an extra step to add a proposal for the new speaker, so we can still test that ze appears in the directory/index
- there is a new scenario `Speakers without proposals do not appear in the directory` that adds a user and ensures they don't proposals, and don't appear in the directory


#### Are there any manual testing steps?

1. Add a new user
2. Check they're not visible on `/speakers`
3. Create a proposal for them
4. Check they are now visible on `/speakers`
5. Create a second proposal for them
6. Check they are only show once on `/speakers`

---

#### Screenshots

#### Deployment instructions

#### Database changes

#### New ENV variables
