### PR TITLE
speakers index edited to remove html table, speakers_index.scss added

### DIFF
--- a/app/assets/stylesheets/speaker-index.scss
+++ b/app/assets/stylesheets/speaker-index.scss
@@ -1,0 +1,5 @@
+
+.speaker {
+    margin-bottom: 8px;
+    list-style-type: none;
+}

--- a/app/views/speakers/index.html.erb
+++ b/app/views/speakers/index.html.erb
@@ -1,3 +1,24 @@
-<% @speakers.each do |speaker| %>
-  <p><%= link_to speaker.name, speaker_path(speaker.id) %></p>
-<% end %>
+<% speakers_columns = @speakers.in_groups(4, false) %>
+
+<div class="row">
+  <div class="three columns">
+    <% speakers_columns[0].each do |speaker| %>
+      <li class="speaker" ><%= link_to speaker.name, speaker_path(speaker.id) %> </li>
+    <% end %>
+  </div>
+  <div class="three columns">
+    <% speakers_columns[1].each do |speaker| %>
+      <li class="speaker" ><%= link_to speaker.name, speaker_path(speaker.id) %> </li>
+    <% end %>
+  </div>
+  <div class="three columns">
+    <% speakers_columns[2].each do |speaker| %>
+      <li class="speaker" ><%= link_to speaker.name, speaker_path(speaker.id) %> </li>
+    <% end %>
+  </div>
+  <div class="three columns">
+    <% speakers_columns[3].each do |speaker| %>
+      <li class="speaker" ><%= link_to speaker.name, speaker_path(speaker.id) %> </li>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
#### What does this PR do?
- Splits speaker index list into three columns. Three selected instead of four to keep it reasonably tidy on small screens. (Revised PR following previous feedback).

##### Why was this work done? Is there a related Issue?
- #33 Speaker index page is not one long list

#### Where should a reviewer start?
- Visual check of Speakers index page 

#### Are there any manual testing steps?
- Change is visual, all tests still passing

---

#### Screenshots
Desktop:
<img width="1309" alt="screen shot 2017-12-08 at 23 52 22" src="https://user-images.githubusercontent.com/19407259/33812024-778afa20-de11-11e7-91a4-09d1b84c1ac3.png">

iPad:
<img width="417" alt="screen shot 2017-12-08 at 23 51 23" src="https://user-images.githubusercontent.com/19407259/33812034-8b77e458-de11-11e7-9521-fb007f28cfdf.png">

iphone5:
<img width="295" alt="screen shot 2017-12-08 at 23 50 56" src="https://user-images.githubusercontent.com/19407259/33812042-9e57403c-de11-11e7-91e3-f111381b169b.png">

#### Deployment instructions
None

#### Database changes
None

#### New ENV variables
None

Hi Nadia,
Is this more in line with what you had in mind? Happy to change it again if you like!
Thanks,
Julie
(Will submit the seeds.rb as a separate PR tomorrow).


