### PR TITLE
Stop trying to save new Event before EventInstance validation

### DIFF
--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -23,7 +23,7 @@ class EventInstance < ApplicationRecord
     if received_bad_event_params
       errors.add(:base, 'choose either an existing event or to create a new one')
     else
-      event || create_event!(name: new_parent_event_name)
+      event || build_event(name: new_parent_event_name)
     end
   end
 


### PR DESCRIPTION
By building the `Event` but not saving it, we’re now allowing it to get autosaved when the `EventInstance` is successfully saved in future, rather than pre-emptively trying to save it during the `before_validation` callback.

This is better than what we were doing before, for two reasons:

1. We only want to really save a new `Event` if the `EventInstance` is also successfully saved. Under the previous arrangement, if the `EventInstance` failed to save for any reason (e.g. its validations didn’t all pass) then we were relying on the transaction rollback to prevent an unwanted `Event` hanging around in the database. This worked but it makes more sense to avoid that situation in the first place.

2. A [change in Rails 5.2.0](https://github.com/rails/rails/commit/9048a70f34b8109be24b2da1009a2f4607ec66bf) makes `create` raise an exception on a singular association (e.g. `belongs_to`) if the parent object isn’t saved yet, so our previous use of `create_event!` will stop working when we upgrade to Rails 5.2.0. This change in Rails was probably motivated by point 1 above.