### PR TITLE
Sort the Events alphabetically when adding a new EventInstance

### DIFF
--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -1,5 +1,6 @@
 class EventInstancesController < ApplicationController
   def new
+    @events = Event.all.order(name: :asc)
     @event_instance = EventInstance.new
   end
 

--- a/app/views/event_instances/new.html.erb
+++ b/app/views/event_instances/new.html.erb
@@ -6,7 +6,7 @@
     <fieldset class="fieldset">
       <legend>Event</legend>
       <%= f.label :event, "Choose an existing event" %>
-      <%= f.collection_select(:event_id, Event.all, :id, :name, prompt: "Add year to an existing event") %>
+      <%= f.collection_select(:event_id, @events, :id, :name, prompt: "Add year to an existing event") %>
 
       <p>&mdash; or &mdash;</p>
 


### PR DESCRIPTION
closes #71 

#### What does this PR do?

Orders Events alphabetically on `EventInstance#new` 

##### Why was this work done? Is there a related Issue?

Related issue: #71. It can be hard to find the Event you're looking for when they aren't sorted!

#### Where should a reviewer start?

The `EventInstancesController`. I added a sorted instance variable `@events` there, then updated the view to use it instead of `Event.all`.

#### Are there any manual testing steps?

---

#### Screenshots
<img width="313" alt="screen shot 2018-10-13 at 8 49 40 am" src="https://user-images.githubusercontent.com/12753198/46905659-e8d53980-cec4-11e8-8e0b-de4bb156cb12.png">

#### Deployment instructions
Nothing special

#### Database changes
None

#### New ENV variables
None