### PR TITLE
Add a Proposals index page

### DIFF
--- a/app/assets/stylesheets/proposals.scss
+++ b/app/assets/stylesheets/proposals.scss
@@ -1,0 +1,8 @@
+.proposal {
+  margin-bottom: 20px;
+  list-style-type: none;
+}
+
+.button-add-proposal {
+  margin-bottom: 30px;
+}

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -1,6 +1,10 @@
 class ProposalsController < ApplicationController
   include ApplicationHelper
 
+  def index
+    @proposals = Proposal.order('title ASC')
+  end
+
   def show
     @proposal = Proposal.find(params[:id])
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
           <div class="inline align-right">
             <li><%= link_to 'Speakers', speakers_path %></li>
             <li><%= link_to 'Add a speaker', new_speaker_path %></li>
-            <li><%= link_to 'Add a proposal', new_proposal_path %></li>
+            <li><%= link_to 'Proposals', proposals_path %></li>
             <li><%= link_to 'Add an event', new_event_instance_path %></li>
           </div>
         </ul>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -1,0 +1,27 @@
+<% proposals_columns = @proposals.in_groups(4, false) %>
+<%= link_to new_proposal_path do %>
+  <button class="button-add-proposal">Add a proposal</button>
+<% end %>
+
+<div class="row">
+  <div class="three columns">
+    <% proposals_columns[0].each do |proposal| %>
+      <li class="proposal" ><%= link_to proposal.title, proposal_path(proposal.id) %> </li>
+    <% end %>
+  </div>
+  <div class="three columns">
+    <% proposals_columns[1].each do |proposal| %>
+      <li class="proposal" ><%= link_to proposal.title, proposal_path(proposal.id) %> </li>
+    <% end %>
+  </div>
+  <div class="three columns">
+    <% proposals_columns[2].each do |proposal| %>
+      <li class="proposal" ><%= link_to proposal.title, proposal_path(proposal.id) %> </li>
+    <% end %>
+  </div>
+  <div class="three columns">
+    <% proposals_columns[3].each do |proposal| %>
+      <li class="proposal" ><%= link_to proposal.title, proposal_path(proposal.id) %> </li>
+    <% end %>
+  </div>
+</div>

--- a/features/step_definitions/proposal_steps.rb
+++ b/features/step_definitions/proposal_steps.rb
@@ -15,6 +15,10 @@ Given(/^I am on the 'Add a Proposal' page$/) do
   visit new_proposal_path
 end
 
+When("I visit the proposals page") do
+  visit proposals_path
+end
+
 When('I add her/his/their proposal with the following information:') do |table|
   proposal_information = table.raw.to_h
   page.select(@speaker.name, from: :proposal_speaker_id)

--- a/features/viewing_proposal_page.feature
+++ b/features/viewing_proposal_page.feature
@@ -1,5 +1,10 @@
 Feature: Proposal Page
 
+  Scenario: Viewing all proposal titles
+    Given there is a proposal called 'A Wonderful Proposal'
+    When I visit the proposals page
+    Then I should see 'A Wonderful Proposal'
+
   Scenario: Viewing a proposal body
     Given the speaker 'Saron Yitbarek' is in the directory
     And she has a proposal called 'Reading Code Good' with the body 'Come learn how to read code good'


### PR DESCRIPTION
#### What does this PR do?

It creates a Proposals index page. It also changes the Nav bar so that it has a `Proposals` link and the `Add a proposal` option now shows up on `Proposals#index`.

##### Why was this work done? Is there a related Issue?

There was no way to view all proposals on the website in one place.

Addresses https://github.com/nodunayo/speakerline/issues/120

#### Where should a reviewer start?

#### Are there any manual testing steps?

---

#### Screenshots

#### Deployment instructions

#### Database changes

#### New ENV variables
