### PR TITLE
refactor new/edit proposal views to use a form partial.  

### DIFF
--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -1,0 +1,22 @@
+<% if @proposal.errors.any? %>
+  <div id="error_explanation">
+    <h5>We couldn't update this proposal because:</h5>
+    <ul>
+      <% @proposal.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= form_for @proposal do |f| %>
+  <%= f.collection_select(:speaker_id, @speakers, :id, :name) %>
+  <%= f.label(:title) %>
+  <%= f.text_field(:title, class: "u-full-width medium-height") %>
+  <%= f.label(:tags, "Tags (comma-separated, max 3)", for: :proposal_tag_list) %>
+  <%= f.text_field(:tag_list, value: @proposal.tag_list.join(", ")) %>
+  <%= f.label(:body) %>
+  <%= f.text_area(:body, class: "u-full-width medium-height", placeholder: "For formatting, you can use Markdown! :-)") %>
+  <%= recaptcha_tags %>
+  <%= f.submit "Save proposal" %>
+<% end %>

--- a/app/views/proposals/edit.html.erb
+++ b/app/views/proposals/edit.html.erb
@@ -1,26 +1,5 @@
-<% if @proposal.errors.any? %>
-  <div id="error_explanation">
-    <h5>We couldn't update this proposal because:</h5>
-    <ul>
-      <% @proposal.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-
 <h3>Edit a proposal</h3>
 
-<%= form_for @proposal, url: {action: 'update'} do |f| %>
-  <%= f.collection_select(:speaker_id, @speakers, :id, :name) %>
-  <%= f.label(:title) %>
-  <%= f.text_field(:title, class: 'u-full-width medium-height') %>
-  <%= f.label(:tags, 'Tags (comma-separated, max 3)') %>
-  <%= f.text_field(:tag_list, value: @proposal.tag_list.join(", ")) %>
-  <%= f.label(:body) %>
-  <%= f.text_area(:body, class: 'u-full-width medium-height', placeholder: "For formatting, you can use Markdown! :-)") %>
-  <%= recaptcha_tags %>
-  <%= f.submit "Update proposal" %>
-<% end %>
+<%= render "form" %>
 
 <p><%= link_to 'Back to Speaker Directory', speakers_path %></p>

--- a/app/views/proposals/new.html.erb
+++ b/app/views/proposals/new.html.erb
@@ -1,26 +1,5 @@
-<% if @proposal.errors.any? %>
-  <div id="error_explanation">
-    <h5>We couldn't save this proposal because:</h5>
-    <ul>
-      <% @proposal.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-
 <h3>Add a proposal</h3>
 
-<%= form_for @proposal, url: {action: 'create'} do |f| %>
-  <%= f.collection_select(:speaker_id, @speakers, :id, :name) %>
-  <%= f.label(:title) %>
-  <%= f.text_field(:title, :class => 'u-full-width medium-height') %>
-  <%= f.label(:tags, 'Tags (comma-separated, max 3, e.g. "ruby, rails, testing")') %>
-  <%= f.text_field(:tag_list) %>
-  <%= f.label(:body) %>
-  <%= f.text_area(:body, class: 'u-full-width medium-height', placeholder: "For formatting, you can use Markdown! :-)") %>
-  <%= recaptcha_tags %>
-  <%= f.submit "Add proposal" %>
-<% end %>
+<%= render "form" %>
 
 <p><%= link_to 'Back to Speaker Directory', speakers_path %></p>


### PR DESCRIPTION
Also ensures that the tag_list will retain original comma-separation

#### What does this PR do?
Refactor the new and edit proposal views to use a form partial, so that both views retain the same behavior and basic structure, without having to update both files in the case that something changes.  This issue was noticed because the `edit` view had a bit of functionality that the `new` view lacked.

##### Why was this work done? Is there a related Issue?
I found a [bug](https://github.com/nodunayo/speakerline/issues/563) where the tag comma-separation wasn't being retained if a new proposal failed to save.  

#### Where should a reviewer start?
There's a new test added in the proposals_controller_spec.rb file to cover the scenario of a proposal being submitted with too many tags.

#### Are there any manual testing steps?
The scenario described in the above referenced bug can be re-created by, while on the master branch, attempting to add a proposal with too many (4 or more tags).

---

#### Screenshots

#### Deployment instructions

#### Database changes

#### New ENV variables
