### PR TITLE
Issue 568 - The blue used for links doesn't pass WCAG standards

### DIFF
--- a/app/assets/stylesheets/skeleton.css
+++ b/app/assets/stylesheets/skeleton.css
@@ -158,9 +158,9 @@ p {
 /* Links
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 a {
-  color: #1EAEDB; }
+  color: #157D9D; }
 a:hover {
-  color: #0FA0CE; }
+  color: #105165; }
 
 
 /* Buttons
@@ -219,8 +219,8 @@ input[type="submit"].button-primary:focus,
 input[type="reset"].button-primary:focus,
 input[type="button"].button-primary:focus {
   color: #FFF;
-  background-color: #1EAEDB;
-  border-color: #1EAEDB; }
+  background-color: #157D9D;
+  border-color: #157D9D; }
 
 
 /* Forms

--- a/app/assets/stylesheets/skeleton.css
+++ b/app/assets/stylesheets/skeleton.css
@@ -158,7 +158,7 @@ p {
 /* Links
 –––––––––––––––––––––––––––––––––––––––––––––––––– */
 a {
-  color: #157D9D; }
+  color: #147694; }
 a:hover {
   color: #105165; }
 
@@ -219,8 +219,8 @@ input[type="submit"].button-primary:focus,
 input[type="reset"].button-primary:focus,
 input[type="button"].button-primary:focus {
   color: #FFF;
-  background-color: #157D9D;
-  border-color: #157D9D; }
+  background-color: #147694;
+  border-color: #147694; }
 
 
 /* Forms


### PR DESCRIPTION
#### What does this PR do?

Swaps out the blue color used for links and primary buttons. 

##### Why was this work done? Is there a related Issue?

It makes the color accessible, according to WCAG standards (per issue #568)

#### Where should a reviewer start?

Only one file is changed 🤓

#### Are there any manual testing steps?

Load the speakers page to see the difference. 

#### Screenshots

![link-colors](https://github.com/nodunayo/speakerline/assets/6457189/173dd31b-f141-4627-a458-f40100188c50)

#### Deployment instructions

N/A

#### Database changes

N/A

#### New ENV variables

N/A
