### PR TITLE
allow user to search proposals by title and body

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -3,6 +3,9 @@ class ProposalsController < ApplicationController
 
   def index
     @proposals = Proposal.order('title ASC')
+    if params[:search].present?
+      @proposals = @proposals.search(params[:search])
+    end
   end
 
   def show

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -5,6 +5,7 @@ class Proposal < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :body
 
+  scope :search, -> (query) { where("title LIKE ? OR body LIKE ?", "%#{query}%", "%#{query}%") }
 
   acts_as_taggable
   validate :maximum_amount_of_tags

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -1,7 +1,17 @@
 <% proposals_columns = @proposals.in_groups(4, false) %>
-<%= link_to new_proposal_path do %>
-  <button class="button-add">Add a proposal</button>
-<% end %>
+<form method="GET">
+  <div class="row">
+    <label for="search" class="two columns">Search</label>
+    <div class="four columns">
+      <input class="u-full-width" type="text" placeholder="Title or Body" id="search" name="search" value="<%= params[:search] %>">
+    </div>
+    <input class="button-primary two columns" type="submit" value="Search">
+
+    <%= link_to new_proposal_path, class: "two columns" do %>
+      <button class="button-add">Add a proposal</button>
+    <% end %>
+  </div>
+</form>
 
 <div class="row">
   <div class="three columns">

--- a/features/searching_proposals.feature
+++ b/features/searching_proposals.feature
@@ -1,0 +1,11 @@
+Feature: Search Proposals
+
+  Scenario: Search the proposals list
+    Given the speaker 'Kathyrn Keebler' is in the directory
+    And she has a proposal called 'Hotwire is the future' with the body 'Come learn about how cool hotwire is'
+    And she has a proposal called 'JavaScript is rough' with the body 'I do not like it'
+    And I visit the proposals page
+    When I search proposals with the following information:
+      | search | Hotwire |
+    Then I should see 'Hotwire is the future'
+    And I should not see 'JavaScript is rough'

--- a/features/step_definitions/proposal_steps.rb
+++ b/features/step_definitions/proposal_steps.rb
@@ -28,6 +28,12 @@ When("I visit the proposals page") do
   visit proposals_path
 end
 
+When('I search proposals with the following information:') do |table|
+  search_information = table.raw.to_h
+  page.fill_in(:search, with: search_information['search'])
+  page.click_on('Search')
+end
+
 When('I add her/his/their proposal with the following information:') do |table|
   proposal_information = table.raw.to_h
   @tags = proposal_information['tags']

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -10,4 +10,12 @@ RSpec.describe Proposal do
     proposal.valid?
     expect(proposal.errors[:base]).to include("must only have a maximum of 3 tags")
   end
+
+  it 'searches proposals' do
+    proposal1 = create(:proposal, title: "Rails is awesome")
+    proposal2 = create(:proposal, title: "Hotwire is amazing")
+    search_results = Proposal.search("amazing")
+    expect(search_results).not_to include(proposal1)
+    expect(search_results).to include(proposal2)
+  end
 end


### PR DESCRIPTION
#### What does this PR do?
Adds the ability for a user to enter a search term to filter down the displayed proposals to only the entries that contain that term in the title or body fields.

##### Why was this work done? Is there a related Issue?
Addresses issue #123 

#### Where should a reviewer start?
Have both a unit test for the Proposal's search scope, and a feature test for the proposals index page itself.

#### Are there any manual testing steps?
Visit the proposals index page, enter a Search term in the input field and click the new "Search" button. 
---

#### Screenshots
<img width="1030" alt="Screenshot 2024-05-08 at 12 13 00 PM" src="https://github.com/nodunayo/speakerline/assets/611713/7c41af29-f0ab-4f09-82a3-edb8b3520842">


