### PR TITLE
Fully removing ActiveStorage to fix #569

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,24 @@
 require_relative "boot"
 
-require "rails/all"
+# RailsAdmin loads every single model a railtie includes, so it crashes when it tries to
+# load an ActiveStorage model, since ActiveStorage isn't configured in this app.
+# Our solution is to replace rails/all with its components (found here: https://github.com/rails/rails/blob/main/railties/lib/rails/all.rb) and then removing the libraries we don't want loaded at all.
+
+require 'rails'
+
+# Pick the frameworks you want:
+require 'active_record/railtie'
+# require 'active_storage/engine'
+require 'action_controller/railtie'
+require 'action_view/railtie'
+require 'action_mailer/railtie'
+require 'active_job/railtie'
+require "action_cable/engine"
+# require 'action_mailbox/engine' # disabled because it requires active_storage
+# require 'action_text/engine' # disabled because it requires active_storage
+require 'rails/test_unit/railtie'
+
+
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/db/migrate/20240508172840_drop_active_storage_tables.rb
+++ b/db/migrate/20240508172840_drop_active_storage_tables.rb
@@ -1,0 +1,7 @@
+class DropActiveStorageTables < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :active_storage_attachments
+    drop_table :active_storage_variant_records
+    drop_table :active_storage_blobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,37 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_16_163229) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_08_172840) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
-  end
-
-  create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
-    t.bigint "byte_size", null: false
-    t.string "checksum"
-    t.datetime "created_at", precision: nil, null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-  end
-
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
-    t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
 
   create_table "event_instances", id: :serial, force: :cascade do |t|
     t.integer "year", null: false
@@ -107,8 +79,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_16_163229) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "event_instances", "events"
   add_foreign_key "proposals", "speakers"
   add_foreign_key "submissions", "event_instances"


### PR DESCRIPTION
Fixing the RailsAdmin paths (#569).

RailsAdmin was trying to load ActiveStorage models because, even though it wasn't configured, Rails was still loading ActiveStorage's classes. The answer is basically to remove ActiveStorage completely.

Had to replace `require "rails/all"` with requiring the individual railties, so I could remove ActiveStorage entirely and prevent RailsAdmin from detecting it. 

Also dropped the three unused ActiveStorage tables.