### PR TITLE
Issue #154 - Style error messages

### DIFF
--- a/app/assets/stylesheets/forms.css
+++ b/app/assets/stylesheets/forms.css
@@ -1,0 +1,8 @@
+#error_explanation {
+  border-color: #9d3515;
+  background-color: #FCEDE9;
+}
+
+.error {
+  color: #9d3515;
+}

--- a/app/controllers/event_instances_controller.rb
+++ b/app/controllers/event_instances_controller.rb
@@ -7,9 +7,12 @@ class EventInstancesController < ApplicationController
   def create
     @event_instance = EventInstance.new(event_instance_params)
     if verify_recaptcha(model: @event_instance) && @event_instance.save
-      redirect_to speakers_path
+      flash[:notice] = 'Event created successfully!'
+
+      redirect_to events_path
     else
       @events = Event.all.order(name: :asc)
+
       render 'new'
     end
   end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -17,6 +17,8 @@ class ProposalsController < ApplicationController
   def create
     @proposal = Proposal.new(proposal_params)
     if verify_recaptcha(model: @proposal) && @proposal.save
+      flash[:notice] = 'Proposal created successfully!'
+
       redirect_to proposal_path(@proposal)
     else
       @speakers = speakers
@@ -32,6 +34,8 @@ class ProposalsController < ApplicationController
   def update
     @proposal = Proposal.find(params[:id])
     if verify_recaptcha(model: @proposal) && @proposal.update(proposal_params)
+      flash[:notice] = 'Proposal updated successfully!'
+
       redirect_to proposal_path(@proposal)
     else
       @speakers = speakers

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -14,6 +14,8 @@ class SpeakersController < ApplicationController
   def create
     @speaker = Speaker.new(speaker_params)
     if verify_recaptcha(model: @speaker) && @speaker.save
+      flash[:notice] = 'Speaker created successfully!'
+
       redirect_to speakers_path
     else
       render :new

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -8,10 +8,13 @@ class SubmissionsController < ApplicationController
   def create
     @submission = Submission.new(submission_params)
     if verify_recaptcha(model: @submission) && @submission.save
+      flash[:notice] = 'Submission created successfully!'
+
       redirect_to proposal_path(@submission.proposal)
     else
       @proposal = @submission.proposal
       @events = Event.all.order('name ASC')
+
       render 'new'
     end
   end
@@ -25,9 +28,10 @@ class SubmissionsController < ApplicationController
     @submission = Submission.find(params[:id])
     @proposal = @submission.proposal
     if verify_recaptcha(model: @submission) && @submission.update(submission_params)
+      flash[:notice] = 'Submission updated successfully!'
+
       redirect_to proposal_path(@proposal)
     else
-      flash[:alert] = 'Failed to update submission'
       render 'edit'
     end
   end

--- a/app/views/event_instances/new.html.erb
+++ b/app/views/event_instances/new.html.erb
@@ -1,12 +1,6 @@
 <% if @event_instance.errors.any? %>
-  <div id="error_explanation">
-    <h5>We couldn't save this event because:</h5>
-    <ul>
-      <% @event_instance.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
+  <%= render "shared/form_error_display", errors: @event_instance.errors,
+                                          object_type: "event" %>
 <% end %>
 
 <%= form_for @event_instance do |f| %>

--- a/app/views/proposals/_form.html.erb
+++ b/app/views/proposals/_form.html.erb
@@ -1,12 +1,6 @@
 <% if @proposal.errors.any? %>
-  <div id="error_explanation">
-    <h5>We couldn't update this proposal because:</h5>
-    <ul>
-      <% @proposal.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
+  <%= render "shared/form_error_display", errors: @proposal.errors,
+                                          object_type: "proposal" %>
 <% end %>
 
 <%= form_for @proposal do |f| %>

--- a/app/views/shared/_form_error_display.html.erb
+++ b/app/views/shared/_form_error_display.html.erb
@@ -1,0 +1,13 @@
+<%-# locals: errors, object_type %>
+
+<fieldset class="fieldset" id="error_explanation">
+  <legend class="error">Warning</legend>
+  
+  <p>We couldn't save this <%= object_type %>, because:</p>
+
+  <ul>
+    <% errors.full_messages.each do |msg| %>
+      <li class="error"><%= msg %></li>
+    <% end %>
+  </ul>
+</fieldset>

--- a/app/views/speakers/new.html.erb
+++ b/app/views/speakers/new.html.erb
@@ -1,14 +1,10 @@
-<% if @speaker.errors.any? %>
-  <div id="error_explanation">
-    <h5>We couldn't save this speaker because:</h5>
-    <ul>
-      <% @speaker.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
 <h3>Add a speaker</h3>
+
+<% if @speaker.errors.any? %>
+  <%= render "shared/form_error_display", errors: @speaker.errors,
+                                          object_type: "speaker" %>
+<% end %>
+
 <%= form_for @speaker, url: {action: 'create'} do |f| %>
   <%= f.text_field :name, placeholder: "Speaker's name" %>
   <%= recaptcha_tags %>

--- a/app/views/submissions/edit.html.erb
+++ b/app/views/submissions/edit.html.erb
@@ -1,5 +1,11 @@
 <h3>Edit submission</h3>
+
 <p><%= "#{@proposal.title} at #{@submission.event_instance.name_and_year}" %></p>
+
+<% if @submission.errors.any? %>
+  <%= render "shared/form_error_display", errors: @submission.errors,
+                                          object_type: "submission" %>
+<% end %>
 
 <%= form_for @submission, url: {action: 'update'} do |f| %>
   <%= f.hidden_field(:proposal_id, value: @proposal.id) %>

--- a/app/views/submissions/new.html.erb
+++ b/app/views/submissions/new.html.erb
@@ -1,25 +1,29 @@
-<% if @submission.errors.any? %>
-  <div id="error_explanation">
-    <h5>We couldn't save this submission because:</h5>
-    <ul>
-      <% @submission.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>
-
 <h3>Add a submission</h3>
+
+<% if @submission.errors.any? %>
+  <%= render "shared/form_error_display", errors: @submission.errors,
+                                          object_type: "submission" %>
+<% end %>
 
 <%= form_for @submission, url: {action: 'create'} do |f| %>
   <%= f.hidden_field(:proposal_id, value: @proposal.id) %>
   <%= f.grouped_collection_select(:event_instance_id, @events, :instances, :name, :id, :name_and_year) %>
-  <%= f.label(:result_accepted, "Accepted") %>
-  <%= f.radio_button(:result, :accepted) %>
-  <%= f.label(:result_rejected, "Rejected") %>
-  <%= f.radio_button(:result, :rejected) %>
-  <%= f.label(:result_waitlisted, "Waitlisted") %>
-  <%= f.radio_button(:result, :waitlisted) %>
+
+  <%= f.label :result_accepted do %>
+    <%= f.radio_button(:result, :accepted) %>
+    Accepted
+  <% end %>
+
+  <%= f.label :result_rejected do %>
+    <%= f.radio_button(:result, :rejected) %>
+    Rejected
+  <% end %>
+
+  <%= f.label :result_waitlisted do %>
+    <%= f.radio_button(:result, :waitlisted) %>
+    Waitlisted
+  <% end %>
+
   <%= recaptcha_tags %>
   <%= f.submit "Add submission" %>
 <% end %>

--- a/spec/controllers/event_instances_controller_spec.rb
+++ b/spec/controllers/event_instances_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe EventInstancesController do
         it 'creates a new instance' do
           expect(EventInstance).to have_received(:new).with(strong_params(event_id: event.id.to_s, year: '2017'))
         end
-        it { should redirect_to(speakers_path) }
+        it { should redirect_to(events_path) }
       end
 
       context 'for a new event' do
@@ -31,7 +31,7 @@ RSpec.describe EventInstancesController do
           expect(EventInstance).to have_received(:new).with(strong_params(new_parent_event_name: 'The Nu Conference',
                                                                           year:                  '2018'))
         end
-        it { should redirect_to(speakers_path) }
+        it { should redirect_to(events_path) }
       end
     end
 


### PR DESCRIPTION
#### What does this PR do?

1. Styles in-page error messages
2. Standardizes success flash messages in controllers
3. Restyles radio buttons in submission new / edit form

##### Why was this work done? Is there a related Issue?

Issue #154 

#### Where should a reviewer start?

Probably with the new error display partial

#### Are there any manual testing steps?

Attempt to edit or create anything. 

#### Screenshots
<img width="1083" alt="Screen Shot 2024-05-08 at 3 26 48 PM" src="https://github.com/nodunayo/speakerline/assets/6457189/200410f0-8e29-493f-a039-4bbd5432654e">
<img width="1072" alt="Screen Shot 2024-05-08 at 3 25 39 PM" src="https://github.com/nodunayo/speakerline/assets/6457189/c6e825ce-9d92-450b-8944-c6303d7a2d49">
<img width="1018" alt="Screen Shot 2024-05-08 at 3 07 08 PM" src="https://github.com/nodunayo/speakerline/assets/6457189/cf17c6f1-4b79-48a8-8e07-ca99d42fdc33">


#### Deployment instructions

N/A

#### Database changes

N/A

#### New ENV variables

N/A
