### PR TITLE
SubmissionsController: provide helpful redirects when invalid URLs are accessed

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -1,5 +1,16 @@
 class SubmissionsController < ApplicationController
+  def index
+    flash[:notice] = 'To view submissions, do so from a specific proposal.'
+    redirect_to proposals_path
+  end
+
   def new
+    unless params[:proposal].present?
+      flash[:notice] = 'When creating a submission, you must do so from a specific proposal.'
+      redirect_to proposals_path
+      return
+    end
+
     @proposal = Proposal.find(params[:proposal])
     @submission = Submission.new(proposal_id: @proposal.id)
     @events = Event.all.order('name ASC')

--- a/spec/controllers/submissions_controller_spec.rb
+++ b/spec/controllers/submissions_controller_spec.rb
@@ -3,6 +3,22 @@ require 'rails_helper'
 RSpec.describe SubmissionsController do
   let(:proposal) { create(:proposal) }
 
+  describe 'GET #index' do
+    it 'redirects to the proposals create page' do
+      get :index
+      expect(response).to redirect_to(proposals_path)
+      expect(flash[:notice]).to eq('To view submissions, do so from a specific proposal.')
+    end
+  end
+
+  describe 'GET #new' do
+    it 'redirects to the proposals create page' do
+      get :new
+      expect(response).to redirect_to(proposals_path)
+      expect(flash[:notice]).to eq('When creating a submission, you must do so from a specific proposal.')
+    end
+  end
+
   describe 'POST #create' do
     context 'with valid attributes' do
       let(:expected_submission) { Submission.new(proposal: proposal, result: 0) }


### PR DESCRIPTION
#### What does this PR do?

This PR updates the `SubmissionsController` to add an `index` action and update the `new` action.
- In the case of the `index` action, we redirect to the `proposals #index `route and display a `notice` flash message.
- In the case of the `new` action, if there is no `proposal` provided, we redirect to the `proposals #index` route and display a `notice` flash message.

##### Why was this work done? Is there a related Issue?

This work was done in response to [Issue Number 48](https://github.com/nodunayo/speakerline/issues/48), which notes that if someone happens to alter the URL (likely with knowledge of rails routes) to try to view the submissions index/new pages, an unhelpful error page is shown. The flash message should help contextualize the role of a submission, articulating why these pages do not exist (or need to exist).

#### Are there any manual testing steps?

- Navigate to `http://localhost:3000/submissions/new`
- Navigate to `http://localhost:3000/submissions`

#### Caveat about styling

[This related CR](https://github.com/nodunayo/speakerline/pull/574) by Hilary styles the flash messages, so they will look much better than shown below!!

---

#### Screenshots

##### `http://localhost:3000/submissions/new`

<img width="1725" alt="Screenshot 2024-05-08 at 3 35 16 PM" src="https://github.com/nodunayo/speakerline/assets/25068409/e41d9090-fc26-4a4e-a476-65750f75870f">

##### `http://localhost:3000/submissions`

<img width="1726" alt="Screenshot 2024-05-08 at 3 35 03 PM" src="https://github.com/nodunayo/speakerline/assets/25068409/58e10ff2-7ec3-49e2-b18f-db99793e6def">
