### PR TITLE
Creating a new sort order for submissions, fixing #67

### DIFF
--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -18,7 +18,6 @@ class EventInstance < ApplicationRecord
   end
 
   # Sorts by result (accepted, waitlisted, rejected), then by proposal title.
-  # Consider moving to a scope if we want this order in more places.
   def sorted_submissions
     submissions.joins(:proposal)
                .in_order_of(:result, [:accepted, :waitlisted, :rejected])

--- a/app/models/event_instance.rb
+++ b/app/models/event_instance.rb
@@ -17,6 +17,14 @@ class EventInstance < ApplicationRecord
     "#{event.name} #{year}"
   end
 
+  # Sorts by result (accepted, waitlisted, rejected), then by proposal title.
+  # Consider moving to a scope if we want this order in more places.
+  def sorted_submissions
+    submissions.joins(:proposal)
+               .in_order_of(:result, [:accepted, :waitlisted, :rejected])
+               .order('proposals.title')
+  end
+
   private
 
   def set_parent_event

--- a/app/views/shared/_instance_submissions.html.erb
+++ b/app/views/shared/_instance_submissions.html.erb
@@ -1,7 +1,5 @@
 <%-# Sort submissions by title before sorting by result -%>
-<% submissions = instance.submissions.sort_by { |s| s.proposal.title } %>
-
-<% submissions.sort_by(&:result).each do |submission| %>
+<% instance.sorted_submissions.includes(proposal: :speaker).each do |submission| %>
   <p>
     <%= link_to submission.proposal.title, submission.proposal %> -
     <%= link_to submission.proposal.speaker.name, submission.proposal.speaker %> -

--- a/spec/models/event_instance_spec.rb
+++ b/spec/models/event_instance_spec.rb
@@ -70,4 +70,30 @@ RSpec.describe EventInstance do
       end
     end
   end
+
+  describe '#sorted_submissions' do
+    let(:event) { create(:event) }
+    let(:event_instance) { create(:event_instance, event:, year: '2024') }
+
+    context 'when submissions have different results' do
+      it 'sorts by the custom order' do
+        sub1 = create(:submission, event_instance:, result: :rejected)
+        sub2 = create(:submission, event_instance:, result: :accepted)
+        sub3 = create(:submission, event_instance:, result: :waitlisted)
+
+        expect(event_instance.sorted_submissions).to eq([sub2, sub3, sub1])
+      end
+    end
+
+    context 'when submissions have the same result' do
+      it 'sorts by proposal title' do
+        prop1 = create(:proposal, title: 'BBB')
+        prop2 = create(:proposal, title: 'AAA')
+        sub1 = create(:submission, event_instance:, result: :accepted, proposal: prop1)
+        sub2 = create(:submission, event_instance:, result: :accepted, proposal: prop2)
+
+        expect(event_instance.sorted_submissions).to eq([sub2, sub1])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #67 by moving the sort to the SQL query (TIL about [in_order_of](https://edgeapi.rubyonrails.org/classes/ActiveRecord/QueryMethods.html#method-i-in_order_of)!). Because the result sort had to be done in SQL, I rolled the title sort in, as well, for one big query that thankfully seems to run a little faster than then old one.